### PR TITLE
Fix %{suse_version} macro

### DIFF
--- a/rpm/redhat/main/common/CGAL61/main/CGAL61.spec
+++ b/rpm/redhat/main/common/CGAL61/main/CGAL61.spec
@@ -12,7 +12,7 @@ BuildRequires:	blas-devel cmake >= 3.14 fdupes glu-devel gmp-devel
 BuildRequires:	lapack-devel libboost_atomic-devel >= 1.74
 BuildRequires:	libboost_thread-devel >= 1.74 mpfr-devel xz zlib-devel
 Requires:	libcgal-devel = %{version}
-%if 0%{?sle_version} >= 150400 && 0%{?sle_version} < 160000 && 0%{?is_opensuse}
+%if 0%{?suse_version} >= 150400 && 0%{?suse_version} < 160000 && 0%{?is_opensuse}
 BuildRequires:	gcc13-c++
 %else
 BuildRequires:	gcc-c++
@@ -63,7 +63,7 @@ This package provides the documentation for CGAL algorithms.
 %setup -q -n CGAL-%{version} -a1
 
 %build
-%if 0%{?sle_version} >= 150400 && 0%{?sle_version} < 160000 && 0%{?is_opensuse}
+%if 0%{?suse_version} >= 150400 && 0%{?suse_version} < 160000 && 0%{?is_opensuse}
 export CXX="g++-13"
 %endif
 


### PR DESCRIPTION
%{sle_version} fails to expand:

```
+ rpmspec --query --buildrequires --define 'pgmajorversion common' CGAL61.spec
error: CGAL61.spec: line 15: Too many levels of recursion in macro expansion. It is likely caused by recursive macro declaration.
error: query of specfile CGAL61.spec failed, can't parse
```