### PR TITLE
SFCGAL: boost_system is still required on SLES

### DIFF
--- a/rpm/redhat/main/common/SFCGAL/main/sfcgal.spec
+++ b/rpm/redhat/main/common/SFCGAL/main/sfcgal.spec
@@ -43,12 +43,12 @@ BuildRequires:	cmake pgdg-srpm-macros
 
 %if 0%{?suse_version} == 1500
 BuildRequires:	libboost_date_time1_66_0 libboost_thread1_66_0
-BuildRequires:	libboost_serialization1_66_0
+BuildRequires:	libboost_system1_66_0 libboost_serialization1_66_0
 BuildRequires:	libboost_serialization1_66_0-devel libboost_atomic1_66_0-devel
 %endif
 %if 0%{?suse_version} == 1600
 BuildRequires:	libboost_date_time1_86_0 libboost_thread1_86_0
-BuildRequires:	libboost_serialization1_86_0
+BuildRequires:	libboost_system1_86_0 libboost_serialization1_86_0
 BuildRequires:	libboost_serialization1_86_0-devel libboost_atomic1_86_0-devel
 %endif
 %if 0%{?rhel} || 0%{?fedora}


### PR DESCRIPTION
Pre-1.90 boost still needs boost_system:

00:00:19.678 CMake Error at /usr/lib64/cmake/Boost-1.86.0/BoostConfig.cmake:141 (find_package):
00:00:19.678   Could not find a package configuration file provided by "boost_system"
00:00:19.678   (requested version 1.86.0) with any of the following names:
00:00:19.678
00:00:19.678     boost_systemConfig.cmake
00:00:19.678     boost_system-config.cmake
00:00:19.678
00:00:19.678   Add the installation prefix of "boost_system" to CMAKE_PREFIX_PATH or set
00:00:19.678   "boost_system_DIR" to a directory containing one of the above files.  If
00:00:19.678   "boost_system" provides a separate development package or SDK, be sure it
00:00:19.678   has been installed.

Fixup-For: 11b0465d2b