### PR TITLE
New extension - pgdisablelogerror

### DIFF
--- a/rpm/redhat/main/non-common/pgdisablelogerror/main/pgdisablelogerror.spec
+++ b/rpm/redhat/main/non-common/pgdisablelogerror/main/pgdisablelogerror.spec
@@ -1,0 +1,90 @@
+%global sname	pgdisablelogerror
+
+%ifarch ppc64 ppc64le s390 s390x armv7hl
+ %if 0%{?rhel} && 0%{?rhel} == 7
+  %{!?llvm:%global llvm 0}
+ %else
+  %{!?llvm:%global llvm 1}
+ %endif
+%else
+ %{!?llvm:%global llvm 1}
+%endif
+
+Summary:	PostgreSQL Disable Log Error Extension
+Name:		%{sname}_%{pgmajorversion}
+Version:	1.0
+Release:	2PGDG%{?dist}
+License:	BSD
+Source0:	https://github.com/fmbiete/%{sname}/archive/v%{version}.tar.gz
+URL:		https://github.com/fmbiete/%{sname}
+BuildRequires:	postgresql%{pgmajorversion}-devel postgresql%{pgmajorversion}
+BuildRequires:	pgdg-srpm-macros
+Requires:	postgresql%{pgmajorversion}-server
+
+%description
+The PostgreSQL Disable Log Error extension disables server logging for
+specified sql error codes.
+
+This will allow you to omit messages for acceptable errors
+(for example unique key violations - 23505).
+
+%if %llvm
+%package llvmjit
+Summary:	Just-in-time compilation support for pgdisablelogerror
+Requires:	%{name}%{?_isa} = %{version}-%{release}
+%if 0%{?rhel} && 0%{?rhel} == 7
+%ifarch aarch64
+Requires:	llvm-toolset-7.0-llvm >= 7.0.1
+%else
+Requires:	llvm5.0 >= 5.0
+%endif
+%endif
+%if 0%{?suse_version} >= 1315 && 0%{?suse_version} <= 1499
+BuildRequires:  llvm6-devel clang6-devel
+Requires:	llvm6
+%endif
+%if 0%{?suse_version} >= 1500
+BuildRequires:  llvm13-devel clang13-devel
+Requires:	llvm13
+%endif
+%if 0%{?fedora} || 0%{?rhel} >= 8
+Requires:	llvm => 5.0
+%endif
+
+%description llvmjit
+This packages provides JIT support for pgdisablelogerror
+%endif
+
+%prep
+%setup -q -n %{sname}-%{version}
+
+%build
+USE_PGXS=1 PATH=%{pginstdir}/bin/:$PATH %{__make} %{?_smp_mflags}
+
+%install
+%{__rm} -rf %{buildroot}
+USE_PGXS=1 PATH=%{pginstdir}/bin/:$PATH %{__make} %{?_smp_mflags} DESTDIR=%{buildroot} install
+# Install README and howto file under PostgreSQL installation directory:
+%{__install} -d %{buildroot}%{pginstdir}/doc/extension
+%{__install} -m 644 README.md %{buildroot}%{pginstdir}/doc/extension/README-%{sname}.md
+%{__rm} -f %{buildroot}%{pginstdir}/doc/extension/README.md
+
+%clean
+%{__rm} -rf %{buildroot}
+
+%files
+%defattr(-,root,root,-)
+%doc %{pginstdir}/doc/extension/README-%{sname}.md
+%{pginstdir}/lib/%{sname}.so
+%{pginstdir}/share/extension/%{sname}--*.sql
+%{pginstdir}/share/extension/%{sname}.control
+
+%if %llvm
+%files llvmjit
+   %{pginstdir}/lib/bitcode/%{sname}*.bc
+   %{pginstdir}/lib/bitcode/%{sname}/*.bc
+%endif
+
+%changelog
+* Thu Dec 29 2022 Francisco Miguel Biete Banon <fbiete@gmail.com> - 1.0-2
+- Initial RPM packaging


### PR DESCRIPTION
PostgreSQL extension that will disable server logging for specified sql error codes.

This will allow you to omit messages for acceptable errors (for example unique key violations - 23505).

https://github.com/fmbiete/pgdisablelogerror

We are using this spec to build in RHEL v8-10 and PostgreSQL v14-18.
I'm not sure about the soft-link structure, let me know if you want something additional